### PR TITLE
(re)Start weblogic at the end of the delius-core install and set to a…

### DIFF
--- a/roles/delius-core/tasks/main.yml
+++ b/roles/delius-core/tasks/main.yml
@@ -15,3 +15,10 @@
 
 - name: Deploy NDelius
   include: deploy_ndelius.yml
+
+- name: Start weblogic
+    become: yes
+    systemd:
+      name: weblogic.service
+      state: restarted
+      enabled: yes


### PR DESCRIPTION
Small change to start weblogic based on the service changes.

Please do not merge this pull request until the next AMI build can take place, as the service wont exist otherwise. 
(depends on https://github.com/ministryofjustice/hmpps-delius-core-weblogic-installer/pull/3) plus AMI rebuild.