### PR TITLE
Fix WebLogic bootstrap 'missing datasource' issue + speed up bootstrap time

### DIFF
--- a/roles/delius-core/tasks/haproxy.yml
+++ b/roles/delius-core/tasks/haproxy.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: (main/haproxy) Copy scripts
+  copy:
+    src: scripts/wl_proxy_ssl.py
+    dest: /u01/software/wl_proxy_ssl.py
+    mode: 0755
+    owner: oracle
+    group: oinstall
+
 - name: (main/haproxy) Enable WebLogic plugin support in console
   shell: '. ~/.bash_profile && ${WLS_HOME}/common/bin/wlst.sh /u01/software/wl_proxy_ssl.py'
   become: yes
@@ -34,11 +42,3 @@
     name: rh-haproxy18-haproxy
     state: restarted
     enabled: yes
-
-- name: (main/haproxy) Copy scripts
-  copy:
-    src: scripts/wl_proxy_ssl.py
-    dest: /u01/software/wl_proxy_ssl.py
-    mode: 0755
-    owner: oracle
-    group: oinstall

--- a/roles/delius-core/tasks/haproxy.yml
+++ b/roles/delius-core/tasks/haproxy.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: (main/haproxy) Enable WebLogic plugin support in console
+  shell: '. ~/.bash_profile && ${WLS_HOME}/common/bin/wlst.sh /u01/software/wl_proxy_ssl.py'
+  become: yes
+  become_user: oracle
+  environment:
+    weblogic_admin_password: '{{ weblogic_admin_password }}'
+
 - name: (main/haproxy) Install repo
   become: yes
   yum:
@@ -35,10 +42,3 @@
     mode: 0755
     owner: oracle
     group: oinstall
-
-- name: (main/haproxy) Enable WebLogic plugin support in console
-  shell: '. ~/.bash_profile && ${WLS_HOME}/common/bin/wlst.sh /u01/software/wl_proxy_ssl.py'
-  become: yes
-  become_user: oracle
-  environment:
-    weblogic_admin_password: '{{ weblogic_admin_password }}'

--- a/roles/delius-core/tasks/main.yml
+++ b/roles/delius-core/tasks/main.yml
@@ -29,6 +29,13 @@
   become: yes
   become_user: oracle
 
+- name: (main) Start weblogic
+  become: yes
+  systemd:
+    name: weblogic.service
+    state: started
+    enabled: yes
+
 - name: (main) Setup security realm
   include: security_realm.yml
   become: yes
@@ -57,13 +64,6 @@
 
 - name: (main) Install proxy to insert SSL header
   include: haproxy.yml
-
-- name: (main) Start weblogic
-  become: yes
-  systemd:
-    name: weblogic.service
-    state: started
-    enabled: yes
 
 - name: (main) set tag to indicate deployed ndelius_version
   ec2_tag:

--- a/roles/delius-core/tasks/main.yml
+++ b/roles/delius-core/tasks/main.yml
@@ -30,7 +30,7 @@
   become_user: oracle
 
 - name: (main) Start weblogic
-  include: start_weblogic.yml
+  include: restart_weblogic.yml
 
 - name: (main) Setup security realm
   include: security_realm.yml
@@ -48,6 +48,12 @@
   become: yes
   become_user: oracle
 
+- name: (main) Install proxy to insert SSL header
+  include: haproxy.yml
+
+- name: (main) Retart weblogic to apply config changes
+  include: restart_weblogic.yml
+
 - name: (main) Deploy NDelius
   include: deploy_ndelius.yml
   become: yes
@@ -57,9 +63,6 @@
   include: deploy_jspell.yml
   become: yes
   become_user: oracle
-
-- name: (main) Install proxy to insert SSL header
-  include: haproxy.yml
 
 - name: (main) set tag to indicate deployed ndelius_version
   ec2_tag:

--- a/roles/delius-core/tasks/main.yml
+++ b/roles/delius-core/tasks/main.yml
@@ -30,11 +30,7 @@
   become_user: oracle
 
 - name: (main) Start weblogic
-  become: yes
-  systemd:
-    name: weblogic.service
-    state: started
-    enabled: yes
+  include: start_weblogic.yml
 
 - name: (main) Setup security realm
   include: security_realm.yml

--- a/roles/delius-core/tasks/main.yml
+++ b/roles/delius-core/tasks/main.yml
@@ -62,7 +62,7 @@
   become: yes
   systemd:
     name: weblogic.service
-    state: restarted
+    state: started
     enabled: yes
 
 - name: (main) set tag to indicate deployed ndelius_version

--- a/roles/delius-core/tasks/restart_weblogic.yml
+++ b/roles/delius-core/tasks/restart_weblogic.yml
@@ -3,7 +3,7 @@
   become: yes
   systemd:
     name: weblogic.service
-    state: started
+    state: restarted
     enabled: yes
 
 - name: (main/start_weblogic) Wait for service to respond

--- a/roles/delius-core/tasks/start_weblogic.yml
+++ b/roles/delius-core/tasks/start_weblogic.yml
@@ -1,0 +1,12 @@
+---
+- name: (main/start_weblogic) Start service
+  become: yes
+  systemd:
+    name: weblogic.service
+    state: started
+    enabled: yes
+
+- name: (main/start_weblogic) Wait for service to respond
+  wait_for:
+    host: localhost
+    port: 7001


### PR DESCRIPTION
Should bootstrap in ~5 mins now (instead of ~25 mins!).

The main change is to start the weblogic service earlier, and only restart it when necessary to apply config changes before deploying. That way the service isn't restarted for every WLST script run.