### PR TITLE
DAM-537 - Scheduled WebLogic restarts

### DIFF
--- a/roles/delius-core/tasks/main.yml
+++ b/roles/delius-core/tasks/main.yml
@@ -69,20 +69,20 @@
   become: yes
   become_user: oracle
 
-- name: (main) Cron job for nightly WebLogic service restart (Every day at 2am)
+- name: (main) Cron job for nightly WebLogic service restart (Every day at 02:15)
   become: yes
   cron:
     name: Restart WebLogic nightly
     job: 'timeout 5 bash -c "</dev/tcp/$(hostname)/61617" || systemctl restart weblogic'
-    minute: '0'
+    minute: '15'
     hour: '2'
 
-- name: (main) Cron job for weekly ActiveMQ service restart (Sunday at midnight)
+- name: (main) Cron job for weekly ActiveMQ service restart (Sunday at 00:15)
   become: yes
   cron:
     name: Restart WebLogic weekly
     job: 'timeout 5 bash -c "</dev/tcp/$(hostname)/61617" && systemctl restart weblogic'
-    minute: '0'
+    minute: '15'
     hour: '0'
     weekday: '0'
 

--- a/roles/delius-core/tasks/main.yml
+++ b/roles/delius-core/tasks/main.yml
@@ -69,13 +69,22 @@
   become: yes
   become_user: oracle
 
-- name: (main) Cron job for nightly service restart
+- name: (main) Cron job for nightly WebLogic service restart (Every day at 2am)
   become: yes
   cron:
     name: Restart WebLogic
-    job: 'systemctl restart weblogic'
+    job: 'timeout 5 bash -c "</dev/tcp/$(hostname)/61617" || systemctl restart weblogic'
     minute: '0'
     hour: '2'
+
+- name: (main) Cron job for weekly ActiveMQ service restart (Sunday at midnight)
+  become: yes
+  cron:
+    name: Restart WebLogic
+    job: 'timeout 5 bash -c "</dev/tcp/$(hostname)/61617" && systemctl restart weblogic'
+    minute: '0'
+    hour: '0'
+    weekday: '0'
 
 - name: (main) set tag to indicate deployed ndelius_version
   ec2_tag:

--- a/roles/delius-core/tasks/main.yml
+++ b/roles/delius-core/tasks/main.yml
@@ -72,7 +72,7 @@
 - name: (main) Cron job for nightly WebLogic service restart (Every day at 2am)
   become: yes
   cron:
-    name: Restart WebLogic
+    name: Restart WebLogic nightly
     job: 'timeout 5 bash -c "</dev/tcp/$(hostname)/61617" || systemctl restart weblogic'
     minute: '0'
     hour: '2'
@@ -80,7 +80,7 @@
 - name: (main) Cron job for weekly ActiveMQ service restart (Sunday at midnight)
   become: yes
   cron:
-    name: Restart WebLogic
+    name: Restart WebLogic weekly
     job: 'timeout 5 bash -c "</dev/tcp/$(hostname)/61617" && systemctl restart weblogic'
     minute: '0'
     hour: '0'


### PR DESCRIPTION
Updated to restart the InService ActiveMQ host every week at 12am, and restart all other hosts every day at 2am.

This ensures minimal JMS broker downtime, while maintaining the required reference data cache updates.

Tested in the dev environment
