### PR TITLE
Temporarily replaced aptracker secret with usermanagement secret

### DIFF
--- a/roles/delius-core/README.md
+++ b/roles/delius-core/README.md
@@ -78,7 +78,6 @@ password_reset_url: PWM (password-reset) url, to be presented on the login page
 
 # Approved Premises Tracker API
 aptracker_api_errors_url: URL for the Approved Premises Tracker API errors screen
-aptracker_api_errors_secret: Shared key to allow Delius authentication for the errors screen
 ```
 
 Example Playbook

--- a/roles/delius-core/templates/NDelius.properties.j2
+++ b/roles/delius-core/templates/NDelius.properties.j2
@@ -58,5 +58,5 @@ DMS_OFFICE_URI_PORT={{ alfresco_office_port }}
 
 # Approved Premises Tracker
 # The APTRACKER_ERRORS_SECRET is left here for backwards compatibility with ND<=4.5.3 only, and will be removed/replaced by USERMANAGEMENT_SECRET in a future build
+APTRACKER_ERRORS_SECRET={{ usermanagement_secret }} # TODO remove this once the NDelius change has been deployed to production and we're confident there is no need to rollback
 APTRACKER_ERRORS_URL={{ aptracker_api_errors_url | default('') }}
-APTRACKER_ERRORS_SECRET={{ usermanagement_secret }}

--- a/roles/delius-core/templates/NDelius.properties.j2
+++ b/roles/delius-core/templates/NDelius.properties.j2
@@ -57,5 +57,6 @@ DMS_OFFICE_URI_HOST={{ alfresco_office_host | regex_replace('\.$', '') }}
 DMS_OFFICE_URI_PORT={{ alfresco_office_port }}
 
 # Approved Premises Tracker
+# The APTRACKER_ERRORS_SECRET is left here for backwards compatibility with ND<=4.5.3 only, and will be removed/replaced by USERMANAGEMENT_SECRET in a future build
 APTRACKER_ERRORS_URL={{ aptracker_api_errors_url | default('') }}
-APTRACKER_ERRORS_SECRET={{ aptracker_api_errors_secret | default('') }}
+APTRACKER_ERRORS_SECRET={{ usermanagement_secret }}


### PR DESCRIPTION
Temporarily replaced aptracker secret with usermanagement secret, for backward compatibility with NDelius<=4.5.3. Later releases of NDelius will no longer use APTRACKER_ERRORS_SECRET for encryption, and will use USERMANAGEMENT_SECRET instead. Until then we need them to be the same value.