### PR TITLE
Add monitoring cron to root user crontab

### DIFF
--- a/roles/delius-core/tasks/monitoring.yml
+++ b/roles/delius-core/tasks/monitoring.yml
@@ -13,9 +13,11 @@
     mode: u+x
 
 - name: (monitoring) Create a cron job to update metrics every minute
+  become: yes
+  become_user: root
   cron:
     name: Update metrics
-    job: . ~/.bash_profile && /u01/software/update_metrics.sh
+    job: sudo -u oracle bash -c '. ~/.bash_profile && /u01/software/update_metrics.sh'
     minute: '*'
     hour: '*'
     day: '*'


### PR DESCRIPTION
This is to resolve the error during bootstrap:
```
TASK [/root/.ansible/roles/hmpps-delius-core-bootstrap/roles/delius-core : (monitoring) Create a cron job to update metrics every minute] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "You (oracle) are not allowed to access to (crontab) because of pam configuration.\n"}
```

Tested by running from a branch in Dev. Bootstrap was successful, and cron job created.