### PR TITLE
Added GDPR url for iframe integration

### DIFF
--- a/roles/delius-core/templates/NDelius.properties.j2
+++ b/roles/delius-core/templates/NDelius.properties.j2
@@ -61,3 +61,5 @@ DMS_OFFICE_URI_PORT={{ alfresco_office_port }}
 # TODO remove this property once the NDelius change has been deployed to production and we're confident there is no need to rollback
 APTRACKER_ERRORS_SECRET={{ usermanagement_secret }}
 APTRACKER_ERRORS_URL={{ aptracker_api_errors_url | default('') }}
+
+GDPR_URL=/gdpr/ui


### PR DESCRIPTION
I've hardcoded this, as it's a fixed value and already hardcoded in other places - so making it configurable here wouldn't add any value.