### PR TITLE
ALS-1610 Fix database wait after failover

### DIFF
--- a/roles/delius-core/tasks/datasources.yml
+++ b/roles/delius-core/tasks/datasources.yml
@@ -1,11 +1,32 @@
 ---
 
+- name: (main/datasources) Temporarily install sqlplus to check database health
+  become: yes
+  become_user: root
+  shell: |
+    yum install -y libaio
+    rpm -i https://download.oracle.com/otn_software/linux/instantclient/oracle-instantclient-basic-linuxx64.rpm
+    rpm -i https://download.oracle.com/otn_software/linux/instantclient/oracle-instantclient-sqlplus-linuxx64.rpm
+
 - name: (main/datasources) Wait for database to be up (max 6 hours)
-  wait_for:
-    host: '{{ primary_db_host }}'
-    port: 1521
-    sleep: 30
-    timeout: 21600
+  shell: |
+    sqlplus -L 'delius_pool/${database_password}@{{ database_url | replace('jdbc:oracle:thin:', '') }}' <<EOF
+    select 1 from dual;
+    EOF
+  environment:
+    database_password: '{{ database_password }}'
+  register: db_healthcheck
+  until: db_healthcheck is success
+  retries: 720
+  delay: 30
+
+- name: (main/datasources) Remove sqlplus
+  become: yes
+  become_user: root
+  shell: |
+    rpm -e oracle-instantclient-sqlplus
+    rpm -e oracle-instantclient-basic
+    yum remove -y libaio
 
 - name: (main/datasources) Copy domain.properties
   template:

--- a/roles/delius-core/tasks/datasources.yml
+++ b/roles/delius-core/tasks/datasources.yml
@@ -2,7 +2,7 @@
 
 - name: (main/datasources) Check if sqlplus is installed
   yum:
-    list: oracle-instantclient-sqlplus
+    list: libaio
   register: yum_sqlplus
 
 - name: (main/datasources) Temporarily install sqlplus to check database health

--- a/roles/delius-core/tasks/datasources.yml
+++ b/roles/delius-core/tasks/datasources.yml
@@ -3,16 +3,19 @@
 - name: (main/datasources) Temporarily install sqlplus to check database health
   become: yes
   become_user: root
-  shell: |
-    yum install -y libaio
-    rpm -i https://download.oracle.com/otn_software/linux/instantclient/oracle-instantclient-basic-linuxx64.rpm
-    rpm -i https://download.oracle.com/otn_software/linux/instantclient/oracle-instantclient-sqlplus-linuxx64.rpm
+  yum:
+    name:
+      - libaio
+      - https://download.oracle.com/otn_software/linux/instantclient/oracle-instantclient-basic-linuxx64.rpm
+      - https://download.oracle.com/otn_software/linux/instantclient/oracle-instantclient-sqlplus-linuxx64.rpm
+    state: present
 
 - name: (main/datasources) Wait for database to be up (max 6 hours)
-  shell: |
-    sqlplus -L 'delius_pool/${database_password}@{{ database_url | replace('jdbc:oracle:thin:', '') }}' <<EOF
-    select 1 from dual;
-    EOF
+  shell:
+    cmd: |
+      sqlplus -L "delius_pool/${database_password}@{{ database_url | regex_replace('^.*@', '') }}" <<EOF
+      select 1 from dual;
+      EOF
   environment:
     database_password: '{{ database_password }}'
   register: db_healthcheck
@@ -23,10 +26,12 @@
 - name: (main/datasources) Remove sqlplus
   become: yes
   become_user: root
-  shell: |
-    rpm -e oracle-instantclient-sqlplus
-    rpm -e oracle-instantclient-basic
-    yum remove -y libaio
+  yum:
+    name:
+      - oracle-instantclient-sqlplus
+      - oracle-instantclient-basic
+      - libaio
+    state: absent
 
 - name: (main/datasources) Copy domain.properties
   template:

--- a/roles/delius-core/tasks/datasources.yml
+++ b/roles/delius-core/tasks/datasources.yml
@@ -1,6 +1,12 @@
 ---
 
+- name: (main/datasources) Check if sqlplus is installed
+  yum:
+    list: oracle-instantclient-sqlplus
+  register: yum_sqlplus
+
 - name: (main/datasources) Temporarily install sqlplus to check database health
+  when: yum_sqlplus.results | selectattr("yumstate", "match", "installed") | list | length == 0
   become: yes
   become_user: root
   yum:

--- a/roles/delius-core/tasks/datasources.yml
+++ b/roles/delius-core/tasks/datasources.yml
@@ -5,6 +5,8 @@
     list: libaio
   register: yum_sqlplus
 
+# SQLPLus has since been added into the AMI.
+# However we check here and install it directly from Oracle if required, to maintain backward-compatibilty while the AMI is still being rolled out.
 - name: (main/datasources) Temporarily install sqlplus to check database health
   when: yum_sqlplus.results | selectattr("yumstate", "match", "installed") | list | length == 0
   become: yes


### PR DESCRIPTION
Uses the sqlplus client to perform a healthcheck using the failover url, rather than pinging port 1521 on the primary database.

Tested in Sandpit, with + without database access.